### PR TITLE
Django 1.11 authenticate

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -201,7 +201,8 @@ def assertion_consumer_service(request,
         create_unknown_user = create_unknown_user()
 
     logger.debug('Trying to authenticate the user')
-    user = auth.authenticate(session_info=session_info,
+    user = auth.authenticate(request=request,
+                             session_info=session_info,
                              attribute_mapping=attribute_mapping,
                              create_unknown_user=create_unknown_user)
     if user is None:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*rnames):
 
 setup(
     name='djangosaml2',
-    version='0.11.0.5-bw',
+    version='0.11.0.6-bw',
     description='pysaml2 integration in Django',
     long_description='\n\n'.join([read('README'), read('CHANGES')]),
     classifiers=[


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/topics/auth/default/

> **Changed in Django 1.11:**
> The optional request argument was added.